### PR TITLE
Use THREE.MathUtils.clamp to be compatible with threejs r141

### DIFF
--- a/lib/physics.js
+++ b/lib/physics.js
@@ -672,7 +672,7 @@ AFRAME.registerSystem('physx', {
 
     const startTime = Date.now();
 
-    this.scene.simulate(THREE.Math.clamp(dt * this.data.speed / 1000, 0, 0.03 * this.data.speed), true)
+    this.scene.simulate(THREE.MathUtils.clamp(dt * this.data.speed / 1000, 0, 0.03 * this.data.speed), true)
     //this.scene.simulate(0.02, true) // (experiment with fixed interval)
     this.scene.fetchResults(true)
 


### PR DESCRIPTION
This is to be compatible with aframe master threejs r141. Note that it's still compatible with aframe 1.2.0 threejs r125.

If you didn't know, @AdaRoseCannon is using your physics.js file in 
https://github.com/AdaRoseCannon/aframe-xr-boilerplate/blob/7e2b63c631eebc244bcafa261e9035ecbdc2c046/index.html#L16