### PR TITLE
no rigidBody to remove if not initialized

### DIFF
--- a/lib/physics.js
+++ b/lib/physics.js
@@ -959,6 +959,7 @@ AFRAME.registerComponent('physx-body', {
     if (!oldData || this.data.mass !== oldData.mass) this.el.emit('object3dset', {})
   },
   remove() {
+    if (!this.rigidBody) return;
     this.system.removeBody(this)
   },
   createGeometry(o) {


### PR DESCRIPTION
I have a use case to start an experience with physx system disabled, so with `autoLoad:false`, I have some entities with physx-body in the scene though waiting to initialize, but I'm not necessary enabling physx if I don't need it. So when I remove the scene, I get the error
```
physics.js:665 Uncaught TypeError: Cannot read properties of undefined (reading 'release')
at i.removeBody (physics.js:665:10)
at n.remove (physics.js:965:17)
```
because those physx-body were never initialized.
just adding a check 
`if (!this.rigidBody) return;` in `remove()` like we do in `update()` fixes the issue.